### PR TITLE
Added toml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Displays the most recent cracked password on the Pwnagotchi display. It currentl
 # Installation
 
 1. SSH into your Pwnagotchi and create a new folder for third-party Pwnagotchi plugins. I use `/root/custom_plugins/` but it doesn't really matter: `mkdir /root/custom_plugins/`
-1. Grab the `display-password.py` file from this Github repo and put it into that custom plugins directory.
+1. Grab the `display-password.py` and `display-password.toml` file from this Github repo and put it into that custom plugins directory.
 1. Edit `/etc/pwnagotchi/config.toml` and change the `main.custom_plugins` variable to point to the custom plugins directory you just created: `main.custom_plugins = "/root/custom_plugins/"`
 1. In the same `/etc/pwnagotchi/config.toml` file, add the following lines to enable the plugin:
 ```

--- a/display-password.toml
+++ b/display-password.toml
@@ -1,0 +1,2 @@
+main.plugins.display-password.enabled = true
+main.plugins.display-password.orientation = "horizontal"


### PR DESCRIPTION
Added a toml config file to the repo so the plugin can be installed from any repo via the CLI.

`sudo pwnagotchi plugins install display-password`

No need to modify /etc/pwnagotchi/config.toml manually afterwards as all necessary changes will be automatically copied from display-password.toml.

Maybe this could be of use for others.