### PR TITLE
Possible fix for known bug

### DIFF
--- a/display-password.py
+++ b/display-password.py
@@ -64,11 +64,9 @@ class DisplayPassword(plugins.Plugin):
 
     def on_ui_update(self, ui):
         if self.peers_detected:
-        # Hide the UI element when peers are detected
-        ui.hide_element('display-password')
-    else:
-        # Display the UI element if no peers are detected
-        ui.show_element('display-password')
+            ui.hide_element('display-password')
+        else:
+            ui.show_element('display-password')
 
         
         last_line = 'tail -n 1 /root/handshakes/wpa-sec.cracked.potfile | awk -F: \'{print $3 " - " $4}\''

--- a/display-password.py
+++ b/display-password.py
@@ -80,3 +80,4 @@ class DisplayPassword(plugins.Plugin):
     # Called when a known peer is lost
     def on_peer_lost(self, agent, peer):
         self.peers_detected = False
+        ui.show_element('display-password')

--- a/display-password.py
+++ b/display-password.py
@@ -22,44 +22,61 @@ class DisplayPassword(plugins.Plugin):
     __license__ = 'GPL3'
     __description__ = 'A plugin to display recently cracked passwords'
 
-    def on_loaded(self):
-        logging.info("display-password loaded")
+def __init__(self):
+    self.peers_detected = False
 
-    def on_ui_setup(self, ui):
-        if ui.is_waveshare_v2():
-            h_pos = (0, 95)
-            v_pos = (180, 61)
-        elif ui.is_waveshare_v1():
-            h_pos = (0, 95)
-            v_pos = (170, 61)
-        elif ui.is_waveshare144lcd():
-            h_pos = (0, 92)
-            v_pos = (78, 67)
-        elif ui.is_inky():
-            h_pos = (0, 83)
-            v_pos = (165, 54)
-        elif ui.is_waveshare27inch():
-            h_pos = (0, 153)
-            v_pos = (216, 122)
-        else:
-            h_pos = (0, 91)
-            v_pos = (180, 61)
+def on_loaded(self):
+    logging.info("display-password loaded")
 
-        if self.options['orientation'] == "vertical":
-            ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
-                                                   position=v_pos,
-                                                   label_font=fonts.Bold, text_font=fonts.Small))
-        else:
-            # default to horizontal
-            ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
-                                                   position=h_pos,
-                                                   label_font=fonts.Bold, text_font=fonts.Small))
+def on_ui_setup(self, ui):
+    if ui.is_waveshare_v2():
+        h_pos = (0, 95)
+        v_pos = (180, 61)
+    elif ui.is_waveshare_v1():
+        h_pos = (0, 95)
+        v_pos = (170, 61)
+    elif ui.is_waveshare144lcd():
+        h_pos = (0, 92)
+        v_pos = (78, 67)
+    elif ui.is_inky():
+        h_pos = (0, 83)
+        v_pos = (165, 54)
+    elif ui.is_waveshare27inch():
+        h_pos = (0, 153)
+        v_pos = (216, 122)
+    else:
+        h_pos = (0, 91)
+        v_pos = (180, 61)
 
-    def on_unload(self, ui):
-        with ui._lock:
-            ui.remove_element('display-password')
+    if self.options['orientation'] == "vertical":
+        ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
+                                               position=v_pos,
+                                               label_font=fonts.Bold, text_font=fonts.Small))
+    else:
+        # default to horizontal
+        ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
+                                               position=h_pos,
+                                               label_font=fonts.Bold, text_font=fonts.Small))
 
-    def on_ui_update(self, ui):
-        last_line = 'tail -n 1 /root/handshakes/wpa-sec.cracked.potfile | awk -F: \'{print $3 " - " $4}\''
-        ui.set('display-password',
-                    "%s" % (os.popen(last_line).read().rstrip()))
+def on_unload(self, ui):
+    with ui._lock:
+        ui.remove_element('display-password')
+
+def on_ui_update(self, ui):
+    if self.peers_detected:
+        # Hide the UI element when peers are detected
+        ui.hide_element('display-password')
+    else:
+        # Display the UI element if no peers are detected
+        ui.show_element('display-password')
+
+    last_line = 'tail -n 1 /root/handshakes/wpa-sec.cracked.potfile | awk -F: \'{print $3 " - " $4}\''
+    ui.set('display-password', "%s" % (os.popen(last_line).read().rstrip()))
+
+# Called when a new peer is detected
+def on_peer_detected(self, agent, peer):
+    self.peers_detected = True
+
+# Called when a known peer is lost
+def on_peer_lost(self, agent, peer):
+    self.peers_detected = False

--- a/display-password.py
+++ b/display-password.py
@@ -23,7 +23,7 @@ class DisplayPassword(plugins.Plugin):
     __description__ = 'A plugin to display recently cracked passwords'
         
     def __init__(self):
-    self.peers_detected = False
+        self.peers_detected = False
     
     def on_loaded(self):
         logging.info("display-password loaded")

--- a/display-password.py
+++ b/display-password.py
@@ -21,57 +21,59 @@ class DisplayPassword(plugins.Plugin):
     __version__ = '1.0.0'
     __license__ = 'GPL3'
     __description__ = 'A plugin to display recently cracked passwords'
-
-def __init__(self):
+    
+    def __init__(self):
     self.peers_detected = False
+    
+    def on_loaded(self):
+        logging.info("display-password loaded")
 
-def on_loaded(self):
-    logging.info("display-password loaded")
+    def on_ui_setup(self, ui):
+        if ui.is_waveshare_v2():
+            h_pos = (0, 95)
+            v_pos = (180, 61)
+        elif ui.is_waveshare_v1():
+            h_pos = (0, 95)
+            v_pos = (170, 61)
+        elif ui.is_waveshare144lcd():
+            h_pos = (0, 92)
+            v_pos = (78, 67)
+        elif ui.is_inky():
+            h_pos = (0, 83)
+            v_pos = (165, 54)
+        elif ui.is_waveshare27inch():
+            h_pos = (0, 153)
+            v_pos = (216, 122)
+        else:
+            h_pos = (0, 91)
+            v_pos = (180, 61)
 
-def on_ui_setup(self, ui):
-    if ui.is_waveshare_v2():
-        h_pos = (0, 95)
-        v_pos = (180, 61)
-    elif ui.is_waveshare_v1():
-        h_pos = (0, 95)
-        v_pos = (170, 61)
-    elif ui.is_waveshare144lcd():
-        h_pos = (0, 92)
-        v_pos = (78, 67)
-    elif ui.is_inky():
-        h_pos = (0, 83)
-        v_pos = (165, 54)
-    elif ui.is_waveshare27inch():
-        h_pos = (0, 153)
-        v_pos = (216, 122)
-    else:
-        h_pos = (0, 91)
-        v_pos = (180, 61)
+        if self.options['orientation'] == "vertical":
+            ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
+                                                   position=v_pos,
+                                                   label_font=fonts.Bold, text_font=fonts.Small))
+        else:
+            # default to horizontal
+            ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
+                                                   position=h_pos,
+                                                   label_font=fonts.Bold, text_font=fonts.Small))
 
-    if self.options['orientation'] == "vertical":
-        ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
-                                               position=v_pos,
-                                               label_font=fonts.Bold, text_font=fonts.Small))
-    else:
-        # default to horizontal
-        ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',
-                                               position=h_pos,
-                                               label_font=fonts.Bold, text_font=fonts.Small))
+    def on_unload(self, ui):
+        with ui._lock:
+            ui.remove_element('display-password')
 
-def on_unload(self, ui):
-    with ui._lock:
-        ui.remove_element('display-password')
-
-def on_ui_update(self, ui):
-    if self.peers_detected:
+    def on_ui_update(self, ui):
+        if self.peers_detected:
         # Hide the UI element when peers are detected
         ui.hide_element('display-password')
     else:
         # Display the UI element if no peers are detected
         ui.show_element('display-password')
 
-    last_line = 'tail -n 1 /root/handshakes/wpa-sec.cracked.potfile | awk -F: \'{print $3 " - " $4}\''
-    ui.set('display-password', "%s" % (os.popen(last_line).read().rstrip()))
+        
+        last_line = 'tail -n 1 /root/handshakes/wpa-sec.cracked.potfile | awk -F: \'{print $3 " - " $4}\''
+        ui.set('display-password',
+                    "%s" % (os.popen(last_line).read().rstrip()))
 
 # Called when a new peer is detected
 def on_peer_detected(self, agent, peer):

--- a/display-password.py
+++ b/display-password.py
@@ -21,7 +21,7 @@ class DisplayPassword(plugins.Plugin):
     __version__ = '1.0.0'
     __license__ = 'GPL3'
     __description__ = 'A plugin to display recently cracked passwords'
-    
+        
     def __init__(self):
     self.peers_detected = False
     
@@ -75,10 +75,10 @@ class DisplayPassword(plugins.Plugin):
         ui.set('display-password',
                     "%s" % (os.popen(last_line).read().rstrip()))
 
-# Called when a new peer is detected
-def on_peer_detected(self, agent, peer):
-    self.peers_detected = True
+    # Called when a new peer is detected
+    def on_peer_detected(self, agent, peer):
+        self.peers_detected = True
 
-# Called when a known peer is lost
-def on_peer_lost(self, agent, peer):
-    self.peers_detected = False
+    # Called when a known peer is lost
+    def on_peer_lost(self, agent, peer):
+        self.peers_detected = False


### PR DESCRIPTION
https://github.com/c-nagy/pwnagotchi-display-password-plugin/issues/3

By adding:

def __init__(self):
self.peers_detected = False

And:
def on_peer_detected(self, agent, peer):
    self.peers_detected = True

def on_peer_lost(self, agent, peer):
    self.peers_detected = False

Then modify def on_ui_update to use self.peers_detected as a trigger to hide and unhide the UI element. The plugin should now hide around peers keeping the two UI elements from overlaying each other.

(untested)