### PR TITLE
Change it to set the coordinates yourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ Displays the most recent cracked password on the Pwnagotchi display. It currentl
 
 # Installation
 
-1. SSH into your Pwnagotchi and create a new folder for third-party Pwnagotchi plugins. I use `/root/custom_plugins/` but it doesn't really matter: `mkdir /root/custom_plugins/`
-1. Grab the `display-password.py` and `display-password.toml` file from this Github repo and put it into that custom plugins directory.
-1. Edit `/etc/pwnagotchi/config.toml` and change the `main.custom_plugins` variable to point to the custom plugins directory you just created: `main.custom_plugins = "/root/custom_plugins/"`
-1. In the same `/etc/pwnagotchi/config.toml` file, add the following lines to enable the plugin:
+1. Grab the `display-password.py` and `display-password.toml` file from this Github repo and put it into your custom plugins directory.
+1. In the `/etc/pwnagotchi/config.toml` file, add the following lines to enable the plugin:
 ```
 main.plugins.display-password.enabled = true
 main.plugins.display-password.orientation = "horizontal"
+main.plugins.display-password.h_pos_x = 0
+main.plugins.display-password.h_pos_y = 91
+main.plugins.display-password.v_pos_x = 180
+main.plugins.display-password.v_pos_y = 61
 ```
 Once the above steps are completed, reboot the Pwnagotchi to ensure all changes are applied.
 

--- a/display-password.py
+++ b/display-password.py
@@ -1,4 +1,4 @@
-# display-password shows recently cracked passwords on the pwnagotchi display 
+# display-password shows recently cracked passwords on the pwnagotchi display
 #
 #
 ###############################################################
@@ -26,24 +26,8 @@ class DisplayPassword(plugins.Plugin):
         logging.info("display-password loaded")
 
     def on_ui_setup(self, ui):
-        if ui.is_waveshare_v2():
-            h_pos = (0, 95)
-            v_pos = (180, 61)
-        elif ui.is_waveshare_v1():
-            h_pos = (0, 95)
-            v_pos = (170, 61)
-        elif ui.is_waveshare144lcd():
-            h_pos = (0, 92)
-            v_pos = (78, 67)
-        elif ui.is_inky():
-            h_pos = (0, 83)
-            v_pos = (165, 54)
-        elif ui.is_waveshare27inch():
-            h_pos = (0, 153)
-            v_pos = (216, 122)
-        else:
-            h_pos = (0, 91)
-            v_pos = (180, 61)
+        h_pos = (self.options['h_pos_x'], self.options['h_pos_y'])
+        v_pos = (self.options['v_pos_x'], self.options['v_pos_y'])
 
         if self.options['orientation'] == "vertical":
             ui.add_element('display-password', LabeledValue(color=BLACK, label='', value='',

--- a/display-password.toml
+++ b/display-password.toml
@@ -1,2 +1,6 @@
 main.plugins.display-password.enabled = true
 main.plugins.display-password.orientation = "horizontal"
+main.plugins.display-password.h_pos_x = 0
+main.plugins.display-password.h_pos_y = 91
+main.plugins.display-password.v_pos_x = 180
+main.plugins.display-password.v_pos_y = 61


### PR DESCRIPTION
This makes it that you can move the text to a different place. This makes it so you can move the text so it doesn't collide with an other plugin or something else. Also my screen got detected wrong and it set the coordinates to outside the screen so with this you know for sure that the text appears where it's supposed to.